### PR TITLE
change md parser kramdown to redcarpet.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,10 +3,13 @@ destination : publish
 
 markdown_ext : "markdown,mkdown,mkdn,mkd,md"
 
-markdown :    kramdown
+markdown :    redcarpet
 highlighter : pygments
 lsi :         false
 excerpt_separator : "\n\n"
 
 kramdown :
   input : GFM
+
+redcarpet :
+  extensions : []


### PR DESCRIPTION
code highlight 를 위한 fenced block 문법을 지원하기 위해 kramdown을 redcarpet으로 변경합니다.
기존의 pygments 방식의 {% highlight %} 좋지만 이것이 atom-shell의 프리뷰에서는 동작이 안되서 수정합니다.
