### PR TITLE
fix #30 issue.

### DIFF
--- a/contents/_plugins/tag_img.rb
+++ b/contents/_plugins/tag_img.rb
@@ -4,12 +4,14 @@ module Jekyll
     def initialize(tag_name, text, tokens)
       super
       @url , *@val= text.split(/ /)
-      @width , *@height = @val[0].split(/x/)
+      if @val.length > 0
+          @width , *@height = @val[0].split(/x/)
 
-      @img_style = "width:#{@width}px;"
+          @img_style = "width:#{@width}px;"
 
-      if @height.length > 0
-        @img_style = @img_style + "height:#{@height[0]}px;"
+          if @height.length > 0
+            @img_style = @img_style + "height:#{@height[0]}px;"
+          end
       end
     end
 
@@ -20,3 +22,28 @@ module Jekyll
 end
 
 Liquid::Template.register_tag('img', Jekyll::RenderImgTag)
+
+module Jekyll
+  class RenderImgBlock < Liquid::Block
+
+    def initialize(tag_name, text, tokens)
+      super
+      @url , *@val= text.split(/ /)
+      if @val.length > 0
+          @width , *@height = @val[0].split(/x/)
+
+          @img_style = "width:#{@width}px;"
+
+          if @height.length > 0
+            @img_style = @img_style + "height:#{@height[0]}px;"
+          end
+      end
+    end
+
+    def render(context)
+      "<img src=\"#{@url}\" style=\"#{@img_style}\" alt=\"#{super}\" title=\"#{super}\">"
+    end
+  end
+end
+
+Liquid::Template.register_tag('bimg', Jekyll::RenderImgBlock)


### PR DESCRIPTION
alt, title attribute 지원을 위해 Tag Template 이외에 Block Template를 추가.

사용법

```
{% bimg imgs/logo-jquery@2x.png 140x100 %}This is the logo for jquery.{% endbimg %}
```
